### PR TITLE
Add meetup calendar widget

### DIFF
--- a/source/calendar.md
+++ b/source/calendar.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: "Calendar"
+
+---
+# Calendar
+
+<div id="memtech-calendar"></div>
+<script type="text/javascript" src="https://vongrippen.github.io/memtech-calendar/public/bundle.js"></script>

--- a/source/themes/memtech/memtech-sculpin/_layouts/default.html.twig
+++ b/source/themes/memtech/memtech-sculpin/_layouts/default.html.twig
@@ -43,7 +43,7 @@
                                 <li><a href="/blog/2015/05/19/join-memtech-on-slack-chat/">Chat with us</a></li>
                                 <li><a href="{{ site.url }}/newsletter-signup">Newsletter</a></li>
                                 <li><a href="https://groups.google.com/forum/#!forum/memtech" target="_blank">Discussion List</a></li>
-                                <!-- <li><a href="{{ site.url }}/events">Events</a></li> -->
+                                <li><a href="{{ site.url }}/calendar">Calendar</a></li>
                             </ul>
                         </div><!--/.nav-collapse -->
                     </div>


### PR DESCRIPTION
Added a calendar page that pulls events from meetup (looking 6 months ahead and behind) that displays them on a monthly calendar view. Clicking on an event opens a new page to the meetup event. Meetup is not returning event lengths, so for the moment everything is hard-coded as only being 1 hour long until that problem can be resolved in https://github.com/memgo/api