### PR TITLE
Update docker HOWTO for current sculpin CLI

### DIFF
--- a/documentation/with_docker.md
+++ b/documentation/with_docker.md
@@ -1,11 +1,13 @@
 # Developing Using Docker
+
 ## Install Docker
 Follow the apporpriate installation guide provided by [Docker](https://docs.docker.com/installation/#installation) to get setup.
 
-## Run a Sculpin contain
+## Run a Sculpin container
 From the checked out repo
 ```sh
-docker run -d -p 8000:8000 -v "$PWD:/data" clue/sculpin generate --watch --server
+#!/usr/bin/env sh
+docker run -it --rm -p 8000:8000 -v `pwd`:/data -u `id -u` clue/sculpin generate --watch --server
 ```
 
 ## View changes in action
@@ -13,6 +15,6 @@ docker run -d -p 8000:8000 -v "$PWD:/data" clue/sculpin generate --watch --serve
 Browse to your running docker container.
 
 - Linux: [http://localhost:8000](http://localhost:8000)
-- Mac: prbably [http://192.168.59.103:8000](http://192.168.59.103:8000)
+- Mac (as of Summer 2018): [http://localhost:8000](http://localhost:8000)
 
 There, you did it!  Congratulations.


### PR DESCRIPTION
I'm prototyping out some sort of "cool stuff MTF has done in the past" page and I stumbled over what appear to be slightly out of date docs for running `sculpin` in Docker. This PR updates to match what I've found to work as of today on Docker 18.03.