### PR TITLE
Fix Slack sign up

### DIFF
--- a/source/_posts/2015-05-19-join-memtech-on-slack-chat.md
+++ b/source/_posts/2015-05-19-join-memtech-on-slack-chat.md
@@ -18,11 +18,8 @@ By joining our Slack you are agreeing to follow the [Python Code of Conduct](htt
 
 Violators may be removed by moderators.
 
-<iframe src="http://memtechslack.herokuapp.com" width="500px" height="400px" frameBorder="0">
+<iframe src="https://memtechslack.herokuapp.com" width="500px" height="400px" frameBorder="0">
 
 </iframe>
 
-
-
-
-
+If you don't see the sign up form, visit this link to [join the memtech slack team](https://join.slack.com/t/memtech/shared_invite/enQtNjkzNTgwNzM0MzM5LTIwYWEyZGEwYTBmNTU3MjkxNzRjZGZhYTA1MTdmYzdmZmY3YWRjY2U2YzQwNjJhMmRiOWMwZDk0ODEyMGI5OWI)


### PR DESCRIPTION
- Change slack imbed link to `https` to prevent mixed content issue that prevents imbed from loading
- Add backup link in case it still doesn't load