### PR TITLE
Google+ is gone now. Don't tell people to find us there.

### DIFF
--- a/source/about.html.twig
+++ b/source/about.html.twig
@@ -55,9 +55,6 @@ title: About
                             <li>
                                 <a href="https://www.facebook.com/MemphisTechnology" target="_blank">Memphis Technology on Facebook</a>
                             </li>
-                            <li>
-                                <a href="https://plus.google.com/u/1/communities/111617696126688058262" target="_blank">Memphis Technology on Google+</a>
-                            </li>
                         </ul>
                     </p>
 

--- a/source/themes/memtech/memtech-sculpin/_layouts/default.html.twig
+++ b/source/themes/memtech/memtech-sculpin/_layouts/default.html.twig
@@ -96,8 +96,6 @@
                             <li><a href="http://www.meetup.com/memphis-technology-user-groups/" target="_blank">#memtech Events</a></li>
                             <li><a href="http://twitter.com/memtech" target="_blank">@memtech Twitter</a></li>
                             <li><a href="https://www.facebook.com/MemphisTechnology" target="_blank">Facebook</a></li>
-                            <li><a href="https://plus.google.com/u/1/communities/111617696126688058262" target="_blank">Google+</a></li>
-
                         </ul>
                     </div>
                     <div class="well sidebar-nav sponsors-sidebar">

--- a/source/themes/memtech/memtech_v2/_layouts/partials/content.html.twig
+++ b/source/themes/memtech/memtech_v2/_layouts/partials/content.html.twig
@@ -70,9 +70,8 @@
                             <div class="media-body less-width">
                                 <h3 class="media-heading">Join the Conversation</h3>
                                 <p>
-                                    Find us on <a href="http://twitter.com/memtech" target="_blank">Twitter</a>,
-                                    <a href="https://www.facebook.com/MemphisTechnology" target="_blank">Facebook</a>, or
-                                    <a href="https://plus.google.com/u/1/communities/111617696126688058262" target="_blank">Google+</a>.
+                                    Find us on <a href="http://twitter.com/memtech" target="_blank">Twitter</a> or
+                                    <a href="https://www.facebook.com/MemphisTechnology" target="_blank">Facebook</a>.
                                     Drop us an email, <a href="blog/2015/05/19/join-memtech-on-slack-chat/">chat with us on Slack</a> or join our
                                     <a href="https://groups.google.com/forum/#!forum/memtech" target="_blank">discussion list</a>
                                 </p>

--- a/source/themes/memtech/memtech_v2/_layouts/partials/footer.html.twig
+++ b/source/themes/memtech/memtech_v2/_layouts/partials/footer.html.twig
@@ -53,9 +53,6 @@
                         <a href="https://www.facebook.com/MemphisTechnology" target="_blank"><i class="fa fa-facebook"></i></a>
                     </li>
                     <li>
-                        <a href="https://plus.google.com/u/0/communities/111617696126688058262" target="_blank"><i class="fa fa-google-plus"></i></a>
-                    </li>
-                    <li>
                         <a href="https://twitter.com/memtech" target="_blank"><i class="fa fa-twitter"></i></a>
                     </li>
                 </ul>

--- a/source/themes/memtech/memtech_v2/_layouts/partials/header.html.twig
+++ b/source/themes/memtech/memtech_v2/_layouts/partials/header.html.twig
@@ -12,9 +12,6 @@
                         <a href="https://www.facebook.com/MemphisTechnology" target="_blank"><i class="fa fa-facebook"></i></a>
                     </li>
                     <li>
-                        <a href="https://plus.google.com/u/0/communities/111617696126688058262" target="_blank"><i class="fa fa-google-plus"></i></a>
-                    </li>
-                    <li>
                         <a href="https://twitter.com/memtech" target="_blank"><i class="fa fa-twitter"></i></a>
                     </li>
                 </ul>


### PR DESCRIPTION
There's also a blog entry from 2014 that mentions it, but I don't see anywhere that it's linked as canonical the way the "chat with us" post is.