### PR TITLE
Propose new bylaws change to reduce number of board members from 6 to 5

### DIFF
--- a/source/about/bylaws.html.twig
+++ b/source/about/bylaws.html.twig
@@ -23,7 +23,7 @@ title: Memphis Technology Foundation Bylaws
 
                     <ol>
                         <li>
-                            The Board of Directors shall serve without pay and consist of six (6) members.
+                            The Board of Directors shall serve without pay and consist of five (5) members.
                         </li>
                         <li>
                             The Board of Directors (Board) shall serve at the pleasure of the majority of the board.


### PR DESCRIPTION
Based on the Memphis Technology Foundation Bylaws this shall serve as a 7 day notice to all board members regarding the proposed bylaws change to lower the number of board members from 6 to 5 members.

Once 7 days have passed the board may vote to accept this pull request and thus the change in bylaws.